### PR TITLE
Azure creds fix

### DIFF
--- a/.github/workflows/Azure-Build-and-Push.yml
+++ b/.github/workflows/Azure-Build-and-Push.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   main:
     runs-on: ubuntu-latest
+    environment: production_deploy
     permissions:
       contents: read #This is required for actions/checkout
       id-token: write #This is required for requesting the JWT


### PR DESCRIPTION
With the switch to the build and deploy to use releases, the previous configuration of fedrated creds no longer worked.